### PR TITLE
Fix env deletion and remove edit button

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,8 +146,9 @@ def delete_env(env_id):
     conn = get_db_connection()
     conn.execute('DELETE FROM environments WHERE id=?', (env_id,))
     conn.commit()
+    envs = conn.execute('SELECT * FROM environments').fetchall()
     conn.close()
-    return jsonify({'status': 'success'})
+    return render_template('envs_list.html', envs=envs)
 
 @app.route('/toggle_default/<int:env_id>', methods=['POST'])
 def toggle_default(env_id):

--- a/templates/envs_list.html
+++ b/templates/envs_list.html
@@ -24,16 +24,7 @@
           <span>Default</span>
         </label>
         <button
-          hx-get="/envs?list_only=1&edit_id={{ env['id'] }}"
-          hx-target="#envs-list"
-          hx-swap="outerHTML"
-          class="bg-yellow-500 text-white px-2 py-1 rounded hover:bg-yellow-400"
-        >
-          Edit
-        </button>
-        <button
           hx-post="/delete_env/{{ env['id'] }}"
-          hx-get="/envs?list_only=1"
           hx-target="#envs-list"
           hx-swap="outerHTML"
           class="bg-red-600 text-white px-2 py-1 rounded hover:bg-red-500"


### PR DESCRIPTION
## Summary
- remove Edit button from environments list
- return updated environments list HTML after deleting

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6840dee67c6c832eb5be57298dadbdb5