### PR TITLE
Refactor command form JS init

### DIFF
--- a/templates/commands.html
+++ b/templates/commands.html
@@ -63,7 +63,7 @@
 
 <!-- JavaScript for dynamic header/param fields -->
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
+  function initCommandForm() {
     const hdrContainer = document.getElementById('headers-container');
     let hdrCount = parseInt(hdrContainer.dataset.initialHdrCount);
     document.getElementById('add-header').addEventListener('click', function() {
@@ -93,8 +93,20 @@
       prmContainer.appendChild(div);
       prmCount++;
     });
-    document.getElementById('reset-form').addEventListener('click', function() {
-      document.getElementById('command-form').reset();
-    });
+
+    const resetBtn = document.getElementById('reset-form');
+    if (resetBtn) {
+      resetBtn.addEventListener('click', function() {
+        document.getElementById('command-form').reset();
+      });
+    }
+  }
+
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.target.id === 'main-command-form' || evt.target.id === 'command-form') {
+      initCommandForm();
+    }
   });
+
+  initCommandForm();
 </script>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -58,7 +58,7 @@
 
 <!-- JavaScript for dynamic header/param fields -->
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
+  function initCommandForm() {
     const hdrContainer = document.getElementById('headers-container');
     let hdrCount = parseInt(hdrContainer.dataset.initialHdrCount);
     document.getElementById('add-header').addEventListener('click', function() {
@@ -88,8 +88,20 @@
       prmContainer.appendChild(div);
       prmCount++;
     });
-    document.getElementById('reset-form').addEventListener('click', function() {
-      document.getElementById('command-form').reset();
-    });
+
+    const resetBtn = document.getElementById('reset-form');
+    if (resetBtn) {
+      resetBtn.addEventListener('click', function() {
+        document.getElementById('command-form').reset();
+      });
+    }
+  }
+
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.target.id === 'main-command-form' || evt.target.id === 'command-form') {
+      initCommandForm();
+    }
   });
+
+  initCommandForm();
 </script>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -74,7 +74,7 @@
 
 <!-- JavaScript for dynamic header/param fields -->
 <script>
-  document.addEventListener('DOMContentLoaded', function() {
+  function initCommandForm() {
     const hdrContainer = document.getElementById('headers-container');
     let hdrCount = parseInt(hdrContainer.dataset.initialHdrCount);
     document.getElementById('add-header').addEventListener('click', function() {
@@ -104,8 +104,20 @@
       prmContainer.appendChild(div);
       prmCount++;
     });
-    document.getElementById('reset-form-edit').addEventListener('click', function() {
-      window.location.href = '/commands';
-    });
+
+    const cancelBtn = document.getElementById('reset-form-edit');
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', function() {
+        window.location.href = '/commands';
+      });
+    }
+  }
+
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.target.id === 'main-command-form' || evt.target.id === 'command-form') {
+      initCommandForm();
+    }
   });
+
+  initCommandForm();
 </script>


### PR DESCRIPTION
## Summary
- create `initCommandForm()` and call it on load
- reinitialize the command form after HTMX swaps

## Testing
- `python -m py_compile app.py db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e0783358832e8f8783fd367ef691