### PR TITLE
Refresh env list on default change

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,8 +158,9 @@ def toggle_default(env_id):
     conn.execute('UPDATE environments SET is_default=0')
     conn.execute('UPDATE environments SET is_default=1 WHERE id=?', (env_id,))
     conn.commit()
+    envs = conn.execute('SELECT * FROM environments').fetchall()
     conn.close()
-    return jsonify({'status': 'success'})
+    return render_template('envs_list.html', envs=envs)
 
 @app.route('/save_globals', methods=['POST'])
 def save_globals():

--- a/templates/envs_list.html
+++ b/templates/envs_list.html
@@ -18,7 +18,8 @@
             name="is_default"
             {% if env['is_default'] %}checked{% endif %}
             hx-post="/toggle_default/{{ env['id'] }}"
-            hx-swap="none"
+            hx-target="#envs-list"
+            hx-swap="outerHTML"
             class="mr-2"
           >
           <span>Default</span>


### PR DESCRIPTION
## Summary
- refresh environment list on default toggle
- update HTMX attributes for the default checkbox

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e3b52f24832e85aa2af31c598142