### PR TITLE
Fix partial update for commands list

### DIFF
--- a/app.py
+++ b/app.py
@@ -222,6 +222,8 @@ def commands():
             conn.commit()
         except sqlite3.IntegrityError:
             error_msg = 'A command with that name already exists.'
+        list_only = request.args.get('list_only') == '1'
+        form_only = request.args.get('form_only') == '1'
     cmds = conn.execute('SELECT * FROM commands').fetchall()
     conn.close()
     if list_only:


### PR DESCRIPTION
## Summary
- ensure `/commands` checks query params after POST
- render partial template when `list_only` or `form_only` requested

## Testing
- `python -m py_compile app.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_6840e6337234832e80c77d54bd005cf4