### PR TITLE
Remove notes from command UI

### DIFF
--- a/templates/commands.html
+++ b/templates/commands.html
@@ -46,10 +46,6 @@
       <label class="block font-medium">Extract Rule (JMESPath)</label>
       <input type="text" name="extract_rule" id="extract_rule" placeholder="e.g., data.token" class="w-full border rounded px-2 py-1">
     </div>
-    <div class="space-y-2">
-      <label class="block font-medium">Notes</label>
-      <input type="text" name="notes" id="notes" placeholder="Optional description" class="w-full border rounded px-2 py-1">
-    </div>
     <div class="flex space-x-2 mt-3">
       <button type="submit" class="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-600">Save Command</button>
       <button type="button" id="reset-form" class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-400">Reset</button>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -43,10 +43,6 @@
     <label class="block font-medium">Extract Rule (JMESPath)</label>
     <input type="text" name="extract_rule" id="extract_rule" placeholder="e.g., data.token" class="w-full border rounded px-2 py-1">
   </div>
-  <div class="space-y-2">
-    <label class="block font-medium">Notes</label>
-    <input type="text" name="notes" id="notes" placeholder="Optional description" class="w-full border rounded px-2 py-1">
-  </div>
   <div class="flex space-x-2 flex-wrap">
     <button type="submit" class="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-600">Save Command</button>
     <button type="button" id="reset-form" class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-400">Reset</button>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -61,10 +61,6 @@
       <label class="block font-medium">Extract Rule (JMESPath)</label>
       <input type="text" name="extract_rule" value="{{ cmd['extract_rule'] }}" class="w-full border rounded px-2 py-1">
     </div>
-    <div class="space-y-2">
-      <label class="block font-medium">Notes</label>
-      <input type="text" name="notes" value="{{ cmd['notes'] }}" class="w-full border rounded px-2 py-1">
-    </div>
     <div class="flex space-x-2 mt-3">
       <button type="submit" class="bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-600">Update Command</button>
       <button type="button" id="reset-form-edit" class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-400">Cancel</button>


### PR DESCRIPTION
## Summary
- clean up configure command form by removing the notes field

## Testing
- `python -m py_compile app.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_6840e81d2fd4832e8ebd8a7d9a9b19b3