### PR TITLE
Add persistent user globals

### DIFF
--- a/db.py
+++ b/db.py
@@ -37,6 +37,15 @@ CREATE TABLE IF NOT EXISTS commands (
     extract_rule TEXT,
     notes TEXT
 );
+
+CREATE TABLE IF NOT EXISTS global_params (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    gkey TEXT NOT NULL,
+    gvalue TEXT,
+    UNIQUE(user_id, gkey),
+    FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+);
 '''
 
 


### PR DESCRIPTION
## Summary
- add new table `global_params` to store user-specific global parameters
- load global parameters when a user logs in
- persist global parameter changes to the database with upsert and deletion logic

## Testing
- `python -m py_compile app.py db.py`
- manual test: start server, login, save globals, verify record in database and reload

------
https://chatgpt.com/codex/tasks/task_e_6840ebbf506c832ea2531f82134cd063