### PR TITLE
Enhance live log output

### DIFF
--- a/templates/logs.html
+++ b/templates/logs.html
@@ -1,0 +1,5 @@
+{% for entry in logs %}
+  <div class="mb-2 text-sm {% if entry.type == 'error' %}text-red-600{% else %}text-gray-800{% endif %}">
+    <pre class="whitespace-pre-wrap">{{ entry.message }}</pre>
+  </div>
+{% endfor %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -252,6 +252,12 @@
   document.addEventListener('DOMContentLoaded', function() {
     fetchResults();
   });
+
+  document.body.addEventListener('htmx:afterSwap', function(evt) {
+    if (evt.target && evt.target.id === 'log-section') {
+      fetchResults();
+    }
+  });
   function fetchResults() {
     fetch('/results')
       .then(res => res.json())


### PR DESCRIPTION
## Summary
- add detailed request/response logging in `execute_script`
- refresh API results after log updates
- render log entries with new `logs.html` template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840eefb21d4832e848f8f9bf090bdff