### PR TITLE
Ensure POST forms persist without HTMX

### DIFF
--- a/templates/commands.html
+++ b/templates/commands.html
@@ -1,6 +1,6 @@
 <div class="space-y-6">
   <!-- Command Configuration Form (Top-Center) -->
-  <form hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" id="cmd_id">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" id="name" placeholder="Name" class="flex-1 border rounded px-2 py-1" required>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -1,4 +1,4 @@
-<form hx-post="/commands?form_only=1" hx-target="#main-command-form" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+<form method="post" hx-post="/commands?form_only=1" hx-target="#main-command-form" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
   <input type="hidden" name="cmd_id" id="cmd_id">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="max-w-2xl mx-auto">
   <h3 class="text-lg font-semibold mb-4">Edit Command: {{ cmd['name'] }}</h3>
-  <form hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" value="{{ cmd['id'] }}">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" value="{{ cmd['name'] }}" class="flex-1 border rounded px-2 py-1" required>

--- a/templates/envs.html
+++ b/templates/envs.html
@@ -22,6 +22,7 @@
 
   <!-- Add Environment Form -->
   <form
+    method="post"
     hx-post="/envs"
     hx-target="#envs-list"
     hx-swap="outerHTML"
@@ -87,6 +88,7 @@
   <div class="bg-white p-4 rounded shadow">
     <h4 class="font-medium mb-2">Global Parameters</h4>
     <form
+      method="post"
       hx-post="/save_globals"
       hx-swap="none"
       class="space-y-2"

--- a/templates/main.html
+++ b/templates/main.html
@@ -21,6 +21,7 @@
 
     <!-- Add Environment Form (static) -->
     <form
+      method="post"
       hx-post="/envs"
       hx-target="#envs-list"
       hx-swap="outerHTML"
@@ -91,6 +92,7 @@
     <div class="bg-white p-4 rounded shadow">
       <h4 class="font-medium mb-2">Global Parameters</h4>
       <form
+        method="post"
         hx-post="/save_globals"
         hx-swap="none"
         class="space-y-2"


### PR DESCRIPTION
## Summary
- add `method="post"` to all forms that rely on HTMX

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ee5d5060832e8be3c90fc3d87167