### PR TITLE
Support normal form submission for commands

### DIFF
--- a/app.py
+++ b/app.py
@@ -226,8 +226,9 @@ def delete_global(gkey):
 def commands():
     if not is_logged_in():
         return redirect(url_for('login'))
-    list_only = request.args.get('list_only') == '1'
-    form_only = request.args.get('form_only') == '1'
+    hx = request.headers.get('HX-Request') == 'true'
+    list_only = request.args.get('list_only') == '1' if hx else False
+    form_only = request.args.get('form_only') == '1' if hx else False
     conn = get_db_connection()
     error_msg = None
     if request.method == 'POST':
@@ -268,10 +269,12 @@ def commands():
             conn.commit()
         except sqlite3.IntegrityError:
             error_msg = 'A command with that name already exists.'
-        list_only = request.args.get('list_only') == '1'
-        form_only = request.args.get('form_only') == '1'
+        list_only = request.args.get('list_only') == '1' if hx else False
+        form_only = request.args.get('form_only') == '1' if hx else False
     cmds = conn.execute('SELECT * FROM commands').fetchall()
     conn.close()
+    if not hx:
+        return render_template('commands.html', commands=cmds, error_msg=error_msg)
     if list_only:
         return render_template('commands_list.html', commands=cmds)
     if form_only:

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -1,6 +1,6 @@
 <div class="space-y-6">
   <!-- Command Configuration Form (Top-Center) -->
-  <form method="post" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" id="cmd_id">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" id="name" placeholder="Name" class="flex-1 border rounded px-2 py-1" required>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -1,4 +1,4 @@
-<form method="post" hx-post="/commands?form_only=1" hx-target="#main-command-form" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+<form method="post" action="/commands?form_only=1" hx-post="/commands?form_only=1" hx-target="#main-command-form" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
   <input type="hidden" name="cmd_id" id="cmd_id">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="max-w-2xl mx-auto">
   <h3 class="text-lg font-semibold mb-4">Edit Command: {{ cmd['name'] }}</h3>
-  <form method="post" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" value="{{ cmd['id'] }}">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" value="{{ cmd['name'] }}" class="flex-1 border rounded px-2 py-1" required>


### PR DESCRIPTION
## Summary
- add missing `action` attributes to command forms
- handle non-HTMX POST requests in `/commands`

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_6840f525cfe4832e8bcbb60831f27c09