### PR TITLE
Update theme and accent colors

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,17 +8,17 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- HTMX -->
     <script src="https://unpkg.com/htmx.org@1.8.4"></script>
-    <!-- Google Font -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
     <style>
         :root {
-            --primary: #7c79c6;
+            --primary: #F2F2F2;
             --secondary: #96c6dd;
-            --background: #f5f6fb;
-            --accent: #7bae76;
-            --hover-cta: #6e9c69;
-            --text-main: #211e53;
-            --subtext: #46419e;
+            --background: #F9FAFC;
+            --accent: #EBCCEA;
+            --hover-cta: #D8BBD8;
+            --text-main: #211E53;
+            --subtext: #6B6B8B;
         }
         .bg-primary { background-color: var(--primary); }
         .bg-secondary { background-color: var(--secondary); }
@@ -27,7 +27,7 @@
         .bg-edit { background-color: #B7A9FF; }
         .bg-delete { background-color: var(--accent); }
         .bg-update { background-color: var(--hover-cta); }
-        .gradient-execute { background-image: linear-gradient(90deg, var(--primary), var(--accent)); }
+        .gradient-execute { background-image: linear-gradient(90deg, var(--accent), var(--hover-cta)); }
         .hover-cta:hover { background-color: var(--hover-cta); }
         .text-main { color: var(--text-main); }
         .text-sub { color: var(--subtext); }
@@ -41,7 +41,7 @@
         }
 
         input, textarea, select {
-            font-family: monospace;
+            font-family: 'JetBrains Mono', monospace;
         }
     </style>
 </head>

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -47,7 +47,7 @@
       <input type="text" name="extract_rule" id="extract_rule" placeholder="e.g., data.token" class="w-full border rounded px-2 py-1">
     </div>
     <div class="flex space-x-2 mt-3">
-      <button type="submit" class="bg-primary text-main px-4 py-2 rounded hover-cta">Save</button>
+      <button type="submit" class="bg-accent text-main px-4 py-2 rounded hover-cta">Save</button>
       <button type="button" id="reset-form" class="bg-edit text-background px-4 py-2 rounded hover-cta">Reset</button>
     </div>
     {% if error_msg %}

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -44,7 +44,7 @@
     <input type="text" name="extract_rule" id="extract_rule" placeholder="e.g., data.token" class="w-full border rounded px-2 py-1">
   </div>
   <div class="flex space-x-2 flex-wrap">
-    <button type="submit" class="bg-primary text-main px-4 py-2 rounded hover-cta">Save</button>
+    <button type="submit" class="bg-accent text-main px-4 py-2 rounded hover-cta">Save</button>
     <button type="button" id="reset-form" class="bg-edit text-background px-4 py-2 rounded hover-cta">Reset</button>
   </div>
   {% if error_msg %}

--- a/templates/envs.html
+++ b/templates/envs.html
@@ -66,7 +66,7 @@
     <div class="flex space-x-2 mt-2">
       <button
         type="submit"
-        class="bg-primary text-main px-4 py-2 rounded hover-cta"
+        class="bg-accent text-main px-4 py-2 rounded hover-cta"
       >
         Save Environment
       </button>
@@ -166,7 +166,7 @@
       </button>
       <button
         type="submit"
-        class="bg-primary text-main px-4 py-2 rounded hover-cta ml-2"
+        class="bg-accent text-main px-4 py-2 rounded hover-cta ml-2"
       >
         Save
       </button>

--- a/templates/login.html
+++ b/templates/login.html
@@ -14,7 +14,7 @@
             <label class="block mb-1 font-medium">Password</label>
             <input type="password" name="password" class="w-full border rounded px-3 py-2" required>
         </div>
-        <button type="submit" class="w-full bg-primary text-main py-2 rounded hover-cta">Login</button>
+        <button type="submit" class="w-full bg-accent text-main py-2 rounded hover-cta">Login</button>
     </form>
 </div>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -65,7 +65,7 @@
       <div class="flex space-x-2 mt-2">
         <button
           type="submit"
-          class="bg-primary text-main px-4 py-2 rounded hover-cta"
+          class="bg-accent text-main px-4 py-2 rounded hover-cta"
         >
           Save Environment
         </button>
@@ -170,7 +170,7 @@
         </button>
         <button
           type="submit"
-          class="bg-primary text-main px-4 py-2 rounded hover-cta ml-2"
+          class="bg-accent text-main px-4 py-2 rounded hover-cta ml-2"
         >
           Save
         </button>


### PR DESCRIPTION
## Summary
- import JetBrains Mono font and lighten the base color palette
- style buttons to use the new accent shade
- render forms with JetBrains Mono inputs

## Testing
- `python -m py_compile app.py db.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684100a500e8832ea4ecf87368e612dc