### PR TITLE
Enable HTMX form refresh for commands

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, redirect, url_for, session, jsonify
+from flask import Flask, render_template, request, redirect, url_for, session, jsonify, make_response
 from db import init_db, get_db_connection
 import requests
 import jmespath
@@ -229,6 +229,7 @@ def commands():
     hx = request.headers.get('HX-Request') == 'true'
     list_only = request.args.get('list_only') == '1' if hx else False
     form_only = request.args.get('form_only') == '1' if hx else False
+    target = request.args.get('target')
     conn = get_db_connection()
     error_msg = None
     if request.method == 'POST':
@@ -278,7 +279,8 @@ def commands():
     if list_only:
         return render_template('commands_list.html', commands=cmds)
     if form_only:
-        return render_template('commands_form.html', commands=cmds, error_msg=error_msg)
+        target_id = target or 'main-command-form'
+        return render_template('commands_form.html', commands=cmds, error_msg=error_msg, target=target_id)
     return render_template('commands.html', commands=cmds, error_msg=error_msg)
 
 @app.route('/delete_command/<int:cmd_id>', methods=['POST'])

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -1,6 +1,6 @@
 <div class="space-y-6">
   <!-- Command Configuration Form (Top-Center) -->
-  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshForm')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" id="cmd_id">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" id="name" placeholder="Name" class="flex-1 border rounded px-2 py-1" required>
@@ -57,6 +57,7 @@
 
   <!-- Command list loaded via HTMX -->
   <div hx-get="/commands?list_only=1" hx-trigger="load" hx-target="#commands-list" hx-swap="outerHTML"></div>
+  <div hx-get="/commands?form_only=1&target=command-form" hx-trigger="refreshForm from:body" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
   <div id="commands-list"></div>
 
 </div>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -1,4 +1,4 @@
-<form method="post" action="/commands?form_only=1" hx-post="/commands?form_only=1" hx-target="#main-command-form" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+<form method="post" action="/commands?form_only=1" hx-post="/commands?form_only=1" hx-target="#{{ target|default('main-command-form') }}" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
   <input type="hidden" name="cmd_id" id="cmd_id">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="max-w-2xl mx-auto">
   <h3 class="text-lg font-semibold mb-4">Edit Command: {{ cmd['name'] }}</h3>
-  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshForm')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" value="{{ cmd['id'] }}">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" value="{{ cmd['name'] }}" class="flex-1 border rounded px-2 py-1" required>
@@ -69,6 +69,7 @@
 
   <!-- Command list loaded via HTMX -->
   <div hx-get="/commands?list_only=1" hx-trigger="load" hx-target="#commands-list" hx-swap="outerHTML"></div>
+  <div hx-get="/commands?form_only=1&target=command-form" hx-trigger="refreshForm from:body" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
   <div id="commands-list"></div>
 </div>
 


### PR DESCRIPTION
## Summary
- update /commands partial to accept configurable hx-target
- refresh commands form via event after saving
- expose target query param in /commands route

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684105e3c990832e866eae030062e6b4