### PR TITLE
Update log text color

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -6,6 +6,7 @@
     --hover-cta: #D8BBD8;
     --text-main: #211E53;
     --subtext: #6B6B8B;
+    --log-text: #1B1744;
 }
 .bg-primary { background-color: var(--primary); }
 .bg-secondary { background-color: var(--secondary); }
@@ -21,6 +22,7 @@
 .hover-text-cta:hover { color: var(--hover-cta); }
 .text-accent { color: var(--accent); }
 .text-background { color: var(--background); }
+.text-log { color: var(--log-text); }
 
 /* Font settings */
 label, h1, h2, h3, h4, h5, h6 {

--- a/templates/logs.html
+++ b/templates/logs.html
@@ -1,5 +1,5 @@
 {% for entry in logs %}
-  <div class="mb-2 text-sm {% if entry.type == 'error' %}text-accent{% else %}text-main{% endif %}">
+  <div class="mb-2 text-sm {% if entry.type == 'error' %}text-accent{% else %}text-log{% endif %}">
     <pre class="whitespace-pre-wrap">{{ entry.message }}</pre>
   </div>
 {% endfor %}


### PR DESCRIPTION
## Summary
- add a new log text color variable and `.text-log` class
- use the new class for non-error log entries

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684108df12d0832eb4178517bc144e9f