### PR TITLE
Add persistent request logging

### DIFF
--- a/db.py
+++ b/db.py
@@ -46,6 +46,16 @@ CREATE TABLE IF NOT EXISTS global_params (
     UNIQUE(user_id, gkey),
     FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS request_logs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    method TEXT NOT NULL,
+    endpoint TEXT NOT NULL,
+    request_body TEXT,
+    status_code INTEGER,
+    response_body TEXT,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 '''
 
 
@@ -63,6 +73,17 @@ def init_db():
     cur.execute("SELECT * FROM users WHERE username = ?", ("SUPER",))
     if cur.fetchone() is None:
         cur.execute("INSERT INTO users (username, password) VALUES (?, ?)", ("SUPER", "SUPER"))
+    conn.commit()
+    conn.close()
+
+
+def log_request(method, endpoint, request_body, status_code, response_body):
+    conn = get_db_connection()
+    conn.execute(
+        'INSERT INTO request_logs (method, endpoint, request_body, status_code, response_body) '
+        'VALUES (?, ?, ?, ?, ?)',
+        (method, endpoint, request_body, status_code, response_body)
+    )
     conn.commit()
     conn.close()
 

--- a/templates/request_logs.html
+++ b/templates/request_logs.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2 class="text-xl font-semibold mb-4">Request Logs</h2>
+<table class="min-w-full border">
+  <thead>
+    <tr>
+      <th class="border px-2 py-1">Time</th>
+      <th class="border px-2 py-1">Method</th>
+      <th class="border px-2 py-1">Endpoint</th>
+      <th class="border px-2 py-1">Status</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for log in logs %}
+    <tr>
+      <td class="border px-2 py-1">{{ log['ts'] }}</td>
+      <td class="border px-2 py-1">{{ log['method'] }}</td>
+      <td class="border px-2 py-1">{{ log['endpoint'] }}</td>
+      <td class="border px-2 py-1">{{ log['status_code'] }}</td>
+    </tr>
+    <tr>
+      <td colspan="4" class="border px-2 py-1">
+        <pre class="whitespace-pre-wrap">Request: {{ log['request_body'] }}
+Response: {{ log['response_body'] }}</pre>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- log HTTP requests/responses into a new `request_logs` table
- expose helper `log_request` in `db.py`
- call `log_request` after command changes and during script execution
- provide `/request_logs` route for viewing stored logs

## Testing
- `python3 -m py_compile app.py db.py`
- `python3 db.py`
- `sqlite3 app.db '.schema request_logs'`

------
https://chatgpt.com/codex/tasks/task_e_68410b1db2b4832e93bd0a680a9e434f