### PR TITLE
Add CodeMirror editor with custom highlighting

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -32,3 +32,9 @@ label, h1, h2, h3, h4, h5, h6 {
 input, textarea, select {
     font-family: 'JetBrains Mono', monospace;
 }
+
+/* CodeMirror token colors */
+.cm-purple { color: purple; }
+.cm-red { color: red; }
+.cm-dblue { color: darkblue; }
+.cm-lblue { color: #1e90ff; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- HTMX -->
     <script src="https://unpkg.com/htmx.org@1.8.4"></script>
+    <!-- CodeMirror CSS & JS -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.css" integrity="sha512-tLdu6o0lbCnS5SMoV/LPuy1kyoyS9MhUlCT3VkOITkkpFmSPrbr30YIOCwRvDDDeWGPAHDLcGRIDcHruM3aXOw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/codemirror.min.js" integrity="sha512-9nuSUXGKmzME2YkdE+5EYXPLkZX31lrT7xvFeoJEB6Digw1VE3DybZ0SqnX+ANXoy2cuglRez2oJ6TP2PzY6kw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/addon/mode/simple.min.js" integrity="sha512-cBeb5GsyhQOdE31E4n4t4WRPcNI0+vrFica8FWHZcizxgxYkWwaP42gnikIze8ih/7gToYtL6vhfVqlhK/SXGg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <!-- Google Font -->
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">

--- a/templates/main.html
+++ b/templates/main.html
@@ -269,6 +269,42 @@
         navigator.clipboard.writeText(logs);
       });
     }
+    initEditor();
+  });
+
+  function initEditor() {
+    fetch('/commands?list_only=1')
+      .then(res => res.text())
+      .then(txt => {
+        const tmp = document.createElement('div');
+        tmp.innerHTML = txt;
+        const cmds = Array.from(tmp.querySelectorAll('.font-semibold'))
+                      .map(el => el.textContent.trim());
+        setupEditor(cmds);
+      })
+      .catch(() => setupEditor([]));
+  }
+
+  function setupEditor(cmds) {
+    const cmdRegex = cmds.length ? new RegExp('\\b(' + cmds.join('|') + ')\\b', 'i') : /$^/;
+    CodeMirror.defineSimpleMode('custom-cmd', {
+      start: [
+        {regex: /\b(?:And|If|Not|Remote|Catch|Inparallel|Null|Try|Else|Is|Or|Finally|Like|Parallel|Raw)\b/, token: 'purple'},
+        {regex: /[+\-*/%]/, token: 'red'},
+        {regex: /\b(?:Select|From|Where|Group\s+by|Order\s+by|Join|On|Insert|Update|Delete)\b/i, token: 'dblue'},
+        {regex: cmdRegex, token: 'lblue'}
+      ]
+    });
+    window.editor = CodeMirror.fromTextArea(document.getElementById('script'), {
+      lineNumbers: true,
+      mode: 'custom-cmd'
+    });
+  }
+
+  document.getElementById('run-btn').addEventListener('click', function() {
+    if (window.editor) {
+      window.editor.save();
+    }
   });
 
   document.body.addEventListener('htmx:afterSwap', function(evt) {


### PR DESCRIPTION
## Summary
- load CodeMirror from CDN in `base.html`
- add custom highlighting classes in `styles.css`
- replace textarea editor with CodeMirror in `main.html` and sync value before executing commands

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_68410f9e2a10832e8dc1091673029fa9