### PR TITLE
Add comment highlighting for CodeMirror

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -38,3 +38,4 @@ input, textarea, select {
 .cm-red { color: red; }
 .cm-dblue { color: darkblue; }
 .cm-lblue { color: #1e90ff; }
+.cm-comment { color: green; }

--- a/templates/main.html
+++ b/templates/main.html
@@ -285,21 +285,26 @@
       .catch(() => setupEditor([]));
   }
 
-  function setupEditor(cmds) {
-    const cmdRegex = cmds.length ? new RegExp('\\b(' + cmds.join('|') + ')\\b', 'i') : /$^/;
-    CodeMirror.defineSimpleMode('custom-cmd', {
-      start: [
-        {regex: /\b(?:And|If|Not|Remote|Catch|Inparallel|Null|Try|Else|Is|Or|Finally|Like|Parallel|Raw)\b/i, token: 'purple'},
-        {regex: /[+\-*/%]/, token: 'red'},
-        {regex: /\b(?:Select|From|Where|Group\s+by|Order\s+by|Join|On|Insert|Update|Delete)\b/i, token: 'dblue'},
-        {regex: cmdRegex, token: 'lblue'}
-      ]
-    });
-    window.editor = CodeMirror.fromTextArea(document.getElementById('script'), {
-      lineNumbers: true,
-      mode: 'custom-cmd'
-    });
-  }
+    function setupEditor(cmds) {
+      const cmdRegex = cmds.length ? new RegExp('\\b(' + cmds.join('|') + ')\\b', 'i') : /$^/;
+      CodeMirror.defineSimpleMode('custom-cmd', {
+        start: [
+          {regex: /\/\*/, token: 'comment', next: 'comment'},
+          {regex: /\b(?:And|If|Not|Remote|Catch|Inparallel|Null|Try|Else|Is|Or|Finally|Like|Parallel|Raw)\b/i, token: 'purple'},
+          {regex: /[+\-*/%]/, token: 'red'},
+          {regex: /\b(?:Select|From|Where|Group\s+by|Order\s+by|Join|On|Insert|Update|Delete)\b/i, token: 'dblue'},
+          {regex: cmdRegex, token: 'lblue'}
+        ],
+        comment: [
+          {regex: /.*?\*\//, token: 'comment', next: 'start'},
+          {regex: /.*/, token: 'comment'}
+        ]
+      });
+      window.editor = CodeMirror.fromTextArea(document.getElementById('script'), {
+        lineNumbers: true,
+        mode: 'custom-cmd'
+      });
+    }
 
   document.getElementById('run-btn').addEventListener('click', function() {
     if (window.editor) {


### PR DESCRIPTION
## Summary
- highlight `/* */` comment blocks as green in the CodeMirror editor

## Testing
- `python -m py_compile app.py db.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684119660ad4832e86c2dde6e3475d71