### PR TITLE
Decouple commands GET and POST

### DIFF
--- a/templates/commands.html
+++ b/templates/commands.html
@@ -1,6 +1,6 @@
 <div class="space-y-6">
   <!-- Command Configuration Form (Top-Center) -->
-  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshForm')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands" hx-post="/commands" hx-target="#command-form" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshList')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" id="cmd_id">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" id="name" placeholder="Name" class="flex-1 border rounded px-2 py-1" required>
@@ -56,8 +56,8 @@
   </form>
 
   <!-- Command list loaded via HTMX -->
-  <div hx-get="/commands?list_only=1" hx-trigger="load" hx-target="#commands-list" hx-swap="outerHTML"></div>
-  <div hx-get="/commands?form_only=1&target=command-form" hx-trigger="refreshForm from:body" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
+  <div hx-get="/commands" hx-trigger="load,refreshList from:body" hx-target="#commands-list" hx-swap="outerHTML"></div>
+  <div hx-get="/commands/form?target=command-form" hx-trigger="load" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
   <div id="commands-list"></div>
 
 </div>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -1,4 +1,4 @@
-<form method="post" action="/commands?form_only=1" hx-post="/commands?form_only=1" hx-target="#{{ target|default('main-command-form') }}" hx-swap="outerHTML" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+<form method="post" action="/commands" hx-post="/commands" hx-target="#{{ target|default('main-command-form') }}" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshList')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
   <input type="hidden" name="cmd_id" id="cmd_id">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="max-w-2xl mx-auto">
   <h3 class="text-lg font-semibold mb-4">Edit Command: {{ cmd['name'] }}</h3>
-  <form method="post" action="/commands?list_only=1" hx-post="/commands?list_only=1" hx-target="#commands-list" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshForm')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands" hx-post="/commands" hx-target="#command-form" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshList')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" value="{{ cmd['id'] }}">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" value="{{ cmd['name'] }}" class="flex-1 border rounded px-2 py-1" required>
@@ -68,8 +68,8 @@
   </form>
 
   <!-- Command list loaded via HTMX -->
-  <div hx-get="/commands?list_only=1" hx-trigger="load" hx-target="#commands-list" hx-swap="outerHTML"></div>
-  <div hx-get="/commands?form_only=1&target=command-form" hx-trigger="refreshForm from:body" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
+  <div hx-get="/commands" hx-trigger="load,refreshList from:body" hx-target="#commands-list" hx-swap="outerHTML"></div>
+  <div hx-get="/commands/form?target=command-form" hx-trigger="load" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
   <div id="commands-list"></div>
 </div>
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -223,7 +223,7 @@
   <div class="col-span-1 md:col-span-1">
     <div class="bg-primary text-main p-4 rounded shadow mb-4">
       <h3 class="text-lg font-semibold mb-2">Configure Command</h3>
-      <div hx-get="/commands?form_only=1" hx-trigger="load" hx-target="#main-command-form" hx-swap="outerHTML"></div>
+      <div hx-get="/commands/form" hx-trigger="load" hx-target="#main-command-form" hx-swap="outerHTML"></div>
       <div id="main-command-form"></div>
     </div>
   </div>
@@ -273,7 +273,7 @@
   });
 
   function initEditor() {
-    fetch('/commands?list_only=1')
+    fetch('/commands')
       .then(res => res.text())
       .then(txt => {
         const tmp = document.createElement('div');


### PR DESCRIPTION
## Summary
- split `/commands` route into GET and POST handlers
- add `/commands/form` route for HTMX form loads
- update templates to use new endpoints

## Testing
- `python3 -m py_compile app.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_684197a8a33c832e851d8b425bfd846a