### PR TITLE
Add color mappings for buttons

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,11 +1,11 @@
 :root {
     --primary: #F2F2F2;
-    --secondary: #96c6dd;
+    --secondary: #7a82f0;
     --background: #F9FAFC;
-    --accent: #EBCCEA;
-    --hover-cta: #D8BBD8;
+    --accent: #71eb77;
+    --hover-cta: #45dd45;
     --text-main: #211E53;
-    --subtext: #6B6B8B;
+    --subtext: #e24e4e;
     --log-text: #1B1744;
 }
 .bg-primary { background-color: var(--primary); }
@@ -13,7 +13,9 @@
 .bg-accent { background-color: var(--accent); }
 .bg-background { background-color: var(--background); }
 .bg-edit { background-color: #B7A9FF; }
-.bg-delete { background-color: var(--accent); }
+.bg-delete { background-color: #e24e4e; }
+.bg-reset { background-color: #e24e4e; }
+.bg-auth { background-color: #a347ee; }
 .bg-update { background-color: var(--hover-cta); }
 .gradient-execute { background-image: linear-gradient(90deg, var(--accent), var(--hover-cta)); }
 .hover-cta:hover { background-color: var(--hover-cta); }

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -48,7 +48,7 @@
     </div>
     <div class="flex space-x-2 mt-3">
       <button type="submit" class="bg-accent text-main px-4 py-2 rounded hover-cta">Save</button>
-      <button type="button" id="reset-form" class="bg-edit text-background px-4 py-2 rounded hover-cta">Reset</button>
+      <button type="button" id="reset-form" class="bg-reset text-background px-4 py-2 rounded hover-cta">Reset</button>
     </div>
     {% if error_msg %}
       <p class="text-accent mt-2">{{ error_msg }}</p>

--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -45,7 +45,7 @@
   </div>
   <div class="flex space-x-2 flex-wrap">
     <button type="submit" class="bg-accent text-main px-4 py-2 rounded hover-cta">Save</button>
-    <button type="button" id="reset-form" class="bg-edit text-background px-4 py-2 rounded hover-cta">Reset</button>
+    <button type="button" id="reset-form" class="bg-reset text-background px-4 py-2 rounded hover-cta">Reset</button>
   </div>
   {% if error_msg %}
     <p class="text-accent mt-2">{{ error_msg }}</p>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -63,7 +63,7 @@
     </div>
     <div class="flex space-x-2 mt-3">
       <button type="submit" class="bg-update text-main px-4 py-2 rounded hover-cta">Update Command</button>
-      <button type="button" id="reset-form-edit" class="bg-edit text-background px-4 py-2 rounded hover-cta">Cancel</button>
+      <button type="button" id="reset-form-edit" class="bg-delete text-background px-4 py-2 rounded hover-cta">Delete</button>
     </div>
   </form>
 

--- a/templates/envs.html
+++ b/templates/envs.html
@@ -13,7 +13,7 @@
       hx-include="[name=auth_url]"
       hx-trigger="click"
       hx-swap="none"
-      class="bg-secondary text-background px-3 py-1 rounded hover-cta"
+      class="bg-auth text-background px-3 py-1 rounded hover-cta"
     >
       Authenticate
     </button>
@@ -73,9 +73,9 @@
       <button
         type="button"
         id="reset-env-form"
-        class="bg-edit text-background px-4 py-2 rounded hover-cta"
+        class="bg-delete text-background px-4 py-2 rounded hover-cta"
       >
-        Cancel
+        Delete
       </button>
     </div>
   </form>

--- a/templates/main.html
+++ b/templates/main.html
@@ -12,7 +12,7 @@
         hx-include="[name=auth_url]"
         hx-trigger="click"
         hx-swap="none"
-        class="bg-secondary text-background px-3 py-1 rounded hover-cta"
+        class="bg-auth text-background px-3 py-1 rounded hover-cta"
       >
         Authenticate
       </button>
@@ -72,9 +72,9 @@
         <button
           type="button"
           id="reset-env-form"
-          class="bg-edit text-background px-4 py-2 rounded hover-cta"
+          class="bg-delete text-background px-4 py-2 rounded hover-cta"
         >
-          Cancel
+          Delete
         </button>
       </div>
     </form>


### PR DESCRIPTION
## Summary
- update base color variables
- add specific color classes for authentication, reset and delete buttons
- apply new classes to buttons and rename Cancel buttons to Delete

## Testing
- `python -m py_compile app.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_68419c77b92c832eb595b381cbce762a