### PR TITLE
Remove command listing and update logging

### DIFF
--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -1,5 +1,4 @@
-<form method="post" action="/commands" hx-post="/commands" hx-target="#{{ target|default('main-command-form') }}" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshList')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
-  <input type="hidden" name="cmd_id" id="cmd_id">
+<form method="post" action="/commands" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>
     <select name="http_method" id="http_method" class="border rounded px-2 py-1">
@@ -93,11 +92,5 @@
     }
   }
 
-  document.body.addEventListener('htmx:afterSwap', function(evt) {
-    if (evt.target.id === 'main-command-form' || evt.target.id === 'command-form') {
-      initCommandForm();
-    }
-  });
-
-  initCommandForm();
+  document.addEventListener('DOMContentLoaded', initCommandForm);
 </script>

--- a/templates/commands_page.html
+++ b/templates/commands_page.html
@@ -2,11 +2,6 @@
 
 {% block content %}
 <div class="space-y-6">
-  {% include 'commands_form.html' with target='command-form' %}
-  <div hx-get="/commands" hx-trigger="load,refreshList from:body" hx-target="#commands-list" hx-swap="outerHTML"></div>
-  <div hx-get="/commands/form?target=command-form" hx-trigger="load" hx-target="#command-form" hx-swap="outerHTML" style="display:none"></div>
-  <div id="commands-list">
-    {% include 'commands_list.html' %}
-  </div>
+  {% include 'commands_form.html' %}
 </div>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -273,16 +273,7 @@
   });
 
   function initEditor() {
-    fetch('/commands?list_only=1')
-      .then(res => res.text())
-      .then(txt => {
-        const tmp = document.createElement('div');
-        tmp.innerHTML = txt;
-        const cmds = Array.from(tmp.querySelectorAll('.font-semibold'))
-                      .map(el => el.textContent.trim());
-        setupEditor(cmds);
-      })
-      .catch(() => setupEditor([]));
+    setupEditor([]);
   }
 
     function setupEditor(cmds) {


### PR DESCRIPTION
## Summary
- refactor command management to remove update/list features
- simplify command form and page
- adjust main template to avoid listing commands
- add debug logging configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bf968a18832ea4cbbeb752471e89