### PR TITLE
Update cursor position after SQL formatting

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -322,7 +322,7 @@
         if (formatted !== src) {
           const cursor = window.editor.getCursor();
           window.editor.setValue(formatted);
-          window.editor.setCursor(cursor);
+          window.editor.setCursor({ line: window.editor.lastLine(), ch: cursor.ch });
         }
       }
       window.editor.on('change', () => {


### PR DESCRIPTION
## Summary
- adjust `formatBracketedSql` to move cursor to the editor's last line after formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c4141878832e972e37d2301e0e62