### PR TITLE
Update inputRead pipe handling

### DIFF
--- a/templates/main.html
+++ b/templates/main.html
@@ -328,6 +328,18 @@
           if (prev === ']') {
             cm.indentLine(pos.line + 1, 0);
           }
+
+          if (change.text.join('') === '') {
+            const lineContent = cm.getLine(pos.line);
+            if (lineContent.trim() === '|') {
+              const indent = lineContent.match(/^\s*/)[0];
+              cm.setLine(pos.line, '|');
+              const nextLine = cm.getLine(pos.line + 1);
+              if (!nextLine.startsWith(indent)) {
+                cm.replaceRange(indent, { line: pos.line + 1, ch: 0 }, { line: pos.line + 1, ch: 0 });
+              }
+            }
+          }
         }
       });
     }


### PR DESCRIPTION
## Summary
- tweak `inputRead` in `main.html` to detect blank pipe lines
- trim indentation of a line consisting of `|` when newline is inserted
- preserve indentation of the newly created line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c5d7dd1c832eaec7662206a0e50b