### PR TITLE
Enable HTMX command form

### DIFF
--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -1,4 +1,11 @@
-<form method="post" action="/commands" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+<form method="post"
+      action="/commands"
+      hx-post="/commands"
+      hx-target="#main-command-form"
+      hx-swap="outerHTML"
+      hx-on="htmx:afterSwap:this.reset()"
+      class="bg-white p-4 rounded shadow space-y-3"
+      id="command-form">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>
     <select name="http_method" id="http_method" class="border rounded px-2 py-1">


### PR DESCRIPTION
## Summary
- use HTMX on the command creation form so submitting keeps the user on the page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cac5d5c0832ea25eb2378516e587