### PR TITLE
Remove edit button from commands list

### DIFF
--- a/templates/commands_list.html
+++ b/templates/commands_list.html
@@ -5,7 +5,6 @@
       <span class="text-sm text-sub">[{{ cmd['http_method'] }}] {{ cmd['endpoint'] }}</span>
     </div>
     <div class="space-x-2">
-      <button hx-get="/edit_command/{{ cmd['id'] }}" hx-target="#main-command-form" hx-swap="outerHTML" class="bg-edit text-background px-2 py-1 rounded hover-cta">Edit</button>
       <button hx-post="/delete_command/{{ cmd['id'] }}" hx-swap="none" class="bg-delete text-main px-2 py-1 rounded hover-cta">Delete</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove edit button from the commands list template so only "Delete" remains

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d1522b54832ebe7b2c16bc595312