### PR TITLE
Add HTMX-powered commands dropdown

### DIFF
--- a/app.py
+++ b/app.py
@@ -310,6 +310,14 @@ def list_commands():
     return render_template('commands_list.html', commands=cmds)
 
 
+@app.get('/commands/dropdown')
+def commands_dropdown():
+    """Return the search + list partial for commands."""
+    if not is_logged_in():
+        return redirect(url_for('login'))
+    return render_template('commands_dropdown.html')
+
+
 @app.get('/commands/form')
 def command_form():
     if not is_logged_in():
@@ -372,7 +380,12 @@ def delete_command(cmd_id):
         return jsonify({'error': 'Internal error'}), 500
     finally:
         conn.close()
-        
+
+    if request.headers.get('HX-Request'):
+        conn = get_db_connection()
+        cmds = conn.execute('SELECT * FROM commands ORDER BY name').fetchall()
+        conn.close()
+        return render_template('commands_list.html', commands=cmds)
     return redirect(url_for('commands_page'))
 
 

--- a/templates/commands_dropdown.html
+++ b/templates/commands_dropdown.html
@@ -1,0 +1,10 @@
+<div class="bg-primary text-main p-4 rounded shadow mb-4" id="commands-dropdown-container">
+  <h3 class="font-semibold mb-2">Commands</h3>
+  <input type="text" name="search" id="cmd-search"
+         placeholder="Search commands..."
+         class="w-full border rounded px-2 py-1 mb-2"
+         hx-get="/commands/list"
+         hx-target="#commands-list"
+         hx-trigger="keyup changed delay:300ms">
+  <div id="commands-list" hx-get="/commands/list" hx-trigger="load" hx-swap="innerHTML"></div>
+</div>

--- a/templates/commands_list.html
+++ b/templates/commands_list.html
@@ -5,7 +5,13 @@
       <span class="text-sm text-sub">[{{ cmd['http_method'] }}] {{ cmd['endpoint'] }}</span>
     </div>
     <div class="space-x-2">
-      <button hx-post="/delete_command/{{ cmd['id'] }}" hx-swap="none" class="bg-delete text-main px-2 py-1 rounded hover-cta">Delete</button>
+      <button
+        hx-post="/delete_command/{{ cmd['id'] }}"
+        hx-target="#commands-list"
+        hx-swap="outerHTML"
+        class="bg-delete text-main px-2 py-1 rounded hover-cta"
+      >Delete</button>
     </div>
   </div>
 {% endfor %}
+

--- a/templates/main.html
+++ b/templates/main.html
@@ -230,6 +230,8 @@
 
   <!-- Right Pane: Live Log -->
   <div class="col-span-1 flex flex-col space-y-4 overflow-auto">
+    <div hx-get="/commands/dropdown" hx-trigger="load" hx-target="#commands-dropdown" hx-swap="innerHTML"></div>
+    <div id="commands-dropdown"></div>
     <div class="bg-primary text-main p-4 rounded shadow flex-1 overflow-auto">
       <div class="flex items-center justify-between mb-2">
         <h3 class="font-semibold">Live Log</h3>


### PR DESCRIPTION
## Summary
- add `/commands/dropdown` view and partial template
- update commands list buttons to refresh via HTMX
- show commands dropdown on main page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841d315d5ac832e91b31001d81bb425