### PR TITLE
Add environment credentials with persist flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,11 +122,14 @@ def envs():
             data = request.form
             env_id = data.get('env_id')
             is_default = 1 if data.get('is_default') == 'on' else 0
+            persist = 1 if data.get('persist') == 'on' else 0
+            username = None if persist else data.get('username')
+            password = None if persist else data.get('password')
             if env_id:
                 if is_default:
                     conn.execute('UPDATE environments SET is_default=0')
                 conn.execute(
-                    'UPDATE environments SET name=?, base_url=?, port=?, default_headers=?, default_params=?, auth_settings=?, meta=?, tags=?, is_default=? WHERE id=?',
+                    'UPDATE environments SET name=?, base_url=?, port=?, default_headers=?, default_params=?, auth_settings=?, meta=?, tags=?, username=?, password=?, persist=?, is_default=? WHERE id=?',
                     (
                         data['name'],
                         data['base_url'],
@@ -136,6 +139,9 @@ def envs():
                         data.get('auth_settings'),
                         data.get('meta'),
                         data.get('tags'),
+                        username,
+                        password,
+                        persist,
                         is_default,
                         env_id
                     )
@@ -144,7 +150,7 @@ def envs():
                 if is_default:
                     conn.execute('UPDATE environments SET is_default=0')
                 conn.execute(
-                    'INSERT INTO environments (name, base_url, port, default_headers, default_params, auth_settings, meta, tags, is_default) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                    'INSERT INTO environments (name, base_url, port, default_headers, default_params, auth_settings, meta, tags, username, password, persist, is_default) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
                     (
                         data['name'],
                         data['base_url'],
@@ -154,6 +160,9 @@ def envs():
                         data.get('auth_settings'),
                         data.get('meta'),
                         data.get('tags'),
+                        username,
+                        password,
+                        persist,
                         is_default
                     )
                 )

--- a/db.py
+++ b/db.py
@@ -25,6 +25,9 @@ CREATE TABLE IF NOT EXISTS environments (
     auth_settings TEXT,
     meta TEXT,
     tags TEXT,
+    username TEXT,
+    password TEXT,
+    persist INTEGER NOT NULL DEFAULT 0,
     is_default INTEGER NOT NULL DEFAULT 0
 );
 

--- a/templates/envs.html
+++ b/templates/envs.html
@@ -53,6 +53,29 @@
         placeholder="Port"
         class="w-20 border rounded px-2 py-1"
       >
+      <input
+        type="text"
+        name="username"
+        id="env_username"
+        placeholder="Username"
+        class="min-w-0 flex-1 border rounded px-2 py-1"
+      >
+      <input
+        type="password"
+        name="password"
+        id="env_password"
+        placeholder="Password"
+        class="min-w-0 flex-1 border rounded px-2 py-1"
+      >
+      <label class="inline-flex items-center ml-2">
+        <input
+          type="checkbox"
+          name="persist"
+          id="env_persist"
+          class="mr-1"
+        >
+        <span>Persist</span>
+      </label>
       <label class="inline-flex items-center ml-2">
         <input
           type="checkbox"
@@ -179,6 +202,18 @@
   document.addEventListener('DOMContentLoaded', function() {
     const gpFields = document.getElementById('global-params-fields');
     let gpCount = parseInt(gpFields.dataset.initialGpCount) + 1;
+
+    const persist = document.getElementById('env_persist');
+    const userField = document.getElementById('env_username');
+    const passField = document.getElementById('env_password');
+
+    function toggleCreds() {
+      const disable = persist.checked;
+      userField.disabled = disable;
+      passField.disabled = disable;
+    }
+    persist.addEventListener('change', toggleCreds);
+    toggleCreds();
 
     document.querySelector('#add-gparam').addEventListener('click', function() {
       const div = document.createElement('div');

--- a/templates/main.html
+++ b/templates/main.html
@@ -52,6 +52,29 @@
           placeholder="Port"
           class="w-20 border rounded px-2 py-1"
         >
+        <input
+          type="text"
+          name="username"
+          id="env_username"
+          placeholder="Username"
+          class="min-w-0 flex-1 border rounded px-2 py-1"
+        >
+        <input
+          type="password"
+          name="password"
+          id="env_password"
+          placeholder="Password"
+          class="min-w-0 flex-1 border rounded px-2 py-1"
+        >
+        <label class="inline-flex items-center ml-2">
+          <input
+            type="checkbox"
+            name="persist"
+            id="env_persist"
+            class="mr-1"
+          >
+          <span>Persist</span>
+        </label>
         <label class="inline-flex items-center ml-2">
           <input
             type="checkbox"
@@ -182,6 +205,18 @@
       document.addEventListener('DOMContentLoaded', function() {
         const gpFields = document.getElementById('global-params-fields');
         let gpCount = parseInt(gpFields.dataset.initialGpCount) + 1;
+
+        const persist = document.getElementById('env_persist');
+        const userField = document.getElementById('env_username');
+        const passField = document.getElementById('env_password');
+
+        function toggleCreds() {
+          const disable = persist.checked;
+          userField.disabled = disable;
+          passField.disabled = disable;
+        }
+        persist.addEventListener('change', toggleCreds);
+        toggleCreds();
 
         document.querySelector('#add-gparam').addEventListener('click', function() {
           const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- allow environments to store username, password, and persist flag
- disable username & password fields when persist is checked
- update database schema and environment save logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841dead8d78832e80e763c1b01361bc