### PR TITLE
Update forms to use bg-primary

### DIFF
--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -4,7 +4,7 @@
       hx-target="#main-command-form"
       hx-swap="outerHTML"
       hx-on="htmx:afterSwap:this.reset()"
-      class="bg-white p-4 rounded shadow space-y-3"
+      class="bg-primary p-4 rounded shadow space-y-3"
       id="command-form">
   <div class="flex space-x-2 items-center flex-wrap">
     <input type="text" name="name" id="name" placeholder="Name" class="min-w-0 flex-1 border rounded px-2 py-1" required>

--- a/templates/edit_command.html
+++ b/templates/edit_command.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="max-w-2xl mx-auto">
   <h3 class="text-lg font-semibold mb-4">Edit Command: {{ cmd['name'] }}</h3>
-  <form method="post" action="/commands" hx-post="/commands" hx-target="#command-form" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshList')" class="bg-white p-4 rounded shadow space-y-3" id="command-form">
+  <form method="post" action="/commands" hx-post="/commands" hx-target="#command-form" hx-swap="outerHTML" hx-on="htmx:afterRequest: htmx.trigger(document.body, 'refreshList')" class="bg-primary p-4 rounded shadow space-y-3" id="command-form">
     <input type="hidden" name="cmd_id" value="{{ cmd['id'] }}">
     <div class="flex space-x-2 items-center">
       <input type="text" name="name" value="{{ cmd['name'] }}" class="flex-1 border rounded px-2 py-1" required>


### PR DESCRIPTION
## Summary
- update command form container to use bg-primary instead of bg-white
- do the same for edit command page

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e495165c832ebb2a444f10ddf676