### PR TITLE
Add focus outline styles

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -35,6 +35,11 @@ input, textarea, select {
     font-family: 'JetBrains Mono', monospace;
 }
 
+/* Remove default outline and add accent ring on focus for form controls */
+input:focus, textarea:focus, select:focus {
+    @apply outline-none ring-2 ring-accent;
+}
+
 /* CodeMirror token colors */
 .cm-purple { color: purple; }
 .cm-red { color: red; }


### PR DESCRIPTION
## Summary
- style: highlight input focus with accent ring using Tailwind utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e73a4574832eb6e2df741c7d0f23