### PR TITLE
Fix command form JS initialization with HTMX

### DIFF
--- a/templates/commands_form.html
+++ b/templates/commands_form.html
@@ -100,4 +100,7 @@
   }
 
   document.addEventListener('DOMContentLoaded', initCommandForm);
+  if (document.readyState !== 'loading') {
+    initCommandForm();
+  }
 </script>

--- a/templates/main.html
+++ b/templates/main.html
@@ -411,6 +411,10 @@
   document.body.addEventListener('htmx:afterSwap', function(evt) {
     if (evt.target && evt.target.id === 'log-section') {
       fetchResults();
+    } else if (evt.target && evt.target.id === 'main-command-form') {
+      if (typeof initCommandForm === 'function') {
+        initCommandForm();
+      }
     }
   });
   function fetchResults() {


### PR DESCRIPTION
## Summary
- invoke `initCommandForm()` when the document is already loaded
- run command form initialization after HTMX swaps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841eff93f30832eb7c6984873944cb0