### PR TITLE
Update auth_toggle to use default env

### DIFF
--- a/templates/envs.html
+++ b/templates/envs.html
@@ -10,7 +10,6 @@
     <button
       id="auth-btn"
       hx-post="/auth_toggle"
-      hx-include="[name=auth_url]"
       hx-trigger="click"
       hx-swap="none"
       class="bg-auth text-background px-3 py-1 rounded hover-cta"
@@ -18,7 +17,6 @@
       Authenticate
     </button>
   </div>
-  <input type="hidden" name="auth_url" value="https://example.com/login">
 
   <!-- Add Environment Form -->
   <form

--- a/templates/main.html
+++ b/templates/main.html
@@ -9,7 +9,6 @@
       <button
         id="auth-btn"
         hx-post="/auth_toggle"
-        hx-include="[name=auth_url]"
         hx-trigger="click"
         hx-swap="none"
         class="bg-auth text-background px-3 py-1 rounded hover-cta"
@@ -17,7 +16,6 @@
         Authenticate
       </button>
     </div>
-    <input type="hidden" name="auth_url" value="https://example.com/login">
 
     <!-- Add Environment Form (static) -->
     <form


### PR DESCRIPTION
## Summary
- update `auth_toggle` to fetch default environment and build auth URL without passing in a form value
- remove hidden auth URL inputs and related `hx-include` attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b20fb1374832eb24769c884cfff86