### PR TITLE
Implement session password handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,7 @@ def login():
                 ).fetchall()
                 conn.close()
                 session['username'] = username
+                session['user_password'] = password
                 gp_dict = {r['gkey']: r['gvalue'] for r in gp_rows}
                 session['global_params'] = {
                     'initial': gp_dict,
@@ -71,6 +72,7 @@ def login():
 
 @app.route('/logout')
 def logout():
+    session.pop('user_password', None)
     session.clear()
     http_session.cookies.clear()
     logger.info('User logged out')
@@ -109,7 +111,7 @@ def auth_toggle():
 
     base = ''
     usr_id = session.get('username')
-    password = session.get('password')
+    password = session.get('user_password')
     if env:
         base = env['base_url'] + (f":{env['port']}" if env['port'] else '')
         if env['username'] is not None:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -11,3 +11,18 @@ def test_login_route(client):
     response = client.get('/login')
     assert response.status_code == 200
 
+
+def test_successful_login_stores_password(client):
+    resp = client.post('/login', data={'username': 'SUPER', 'password': 'SUPER'})
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert sess.get('user_password') == 'SUPER'
+
+
+def test_logout_removes_password(client):
+    client.post('/login', data={'username': 'SUPER', 'password': 'SUPER'})
+    resp = client.get('/logout')
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert 'user_password' not in sess
+


### PR DESCRIPTION
## Summary
- store the user's password in the session after successful login
- clear the stored password on logout
- have `auth_toggle` reference the stored password
- test login/logout session behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b21d22d04832e8c62bd78be00230b