### PR TITLE
Implement auth cookie copy feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,6 +88,15 @@ def main():
     logger.info('Rendering main page for %s', session.get('username'))
     return render_template('main.html', global_params=global_params)
 
+# ─── AUTH COOKIE RETRIEVAL ─────────────────────────────────────────────────────
+
+@app.route('/auth_cookie')
+def auth_cookie():
+    if not is_logged_in():
+        return jsonify({'error': 'Not logged in'}), 401
+    cookie = http_session.cookies.get('MOCA-WS-SESSIONKEY')
+    return jsonify({'cookie': cookie})
+
 # ─── AUTHENTICATE TO EXTERNAL ENDPOINT (CAPTURE COOKIE) ─────────────────────────
 
 @app.route('/auth_toggle', methods=['POST'])
@@ -124,6 +133,7 @@ def auth_toggle():
     try:
         resp = http_session.get(auth_url)
         if resp.status_code == 200:
+            session['auth_cookie'] = http_session.cookies.get('MOCA-WS-SESSIONKEY')
             logger.info('Auth toggle succeeded for %s', usr_id)
             return jsonify({'status': 'success'})
         else:

--- a/templates/envs.html
+++ b/templates/envs.html
@@ -7,15 +7,18 @@
   <!-- Authentication Toggle -->
   <div class="flex items-center justify-between mb-2">
     <h3 class="text-lg font-semibold">Environments</h3>
-    <button
-      id="auth-btn"
-      hx-post="/auth_toggle"
-      hx-trigger="click"
-      hx-swap="none"
-      class="bg-auth text-background px-3 py-1 rounded hover-cta"
-    >
-      Authenticate
-    </button>
+    <div class="flex items-center space-x-2">
+      <button
+        id="auth-btn"
+        hx-post="/auth_toggle"
+        hx-trigger="click"
+        hx-swap="none"
+        class="bg-auth text-background px-3 py-1 rounded hover-cta"
+      >
+        Authenticate
+      </button>
+      <button id="copy-cookie-btn" class="hover-text-cta" title="Copy cookie" type="button">📋</button>
+    </div>
   </div>
 
   <!-- Add Environment Form -->
@@ -210,6 +213,19 @@
   document.addEventListener('DOMContentLoaded', function() {
     const gpFields = document.getElementById('global-params-fields');
     let gpCount = parseInt(gpFields.dataset.initialGpCount) + 1;
+
+    const cookieBtn = document.getElementById('copy-cookie-btn');
+    if (cookieBtn) {
+      cookieBtn.addEventListener('click', function() {
+        fetch('/auth_cookie')
+          .then(res => res.json())
+          .then(data => {
+            if (data.cookie) {
+              navigator.clipboard.writeText(data.cookie);
+            }
+          });
+      });
+    }
 
     // Tab switching logic
     document.querySelectorAll('.tab-btn').forEach(btn => {

--- a/templates/main.html
+++ b/templates/main.html
@@ -6,15 +6,18 @@
     <!-- Authentication Toggle -->
     <div class="flex items-center justify-between mb-2">
       <h3 class="text-lg font-semibold">Environments</h3>
-      <button
-        id="auth-btn"
-        hx-post="/auth_toggle"
-        hx-trigger="click"
-        hx-swap="none"
-        class="bg-auth text-background px-3 py-1 rounded hover-cta"
-      >
-        Authenticate
-      </button>
+      <div class="flex items-center space-x-2">
+        <button
+          id="auth-btn"
+          hx-post="/auth_toggle"
+          hx-trigger="click"
+          hx-swap="none"
+          class="bg-auth text-background px-3 py-1 rounded hover-cta"
+        >
+          Authenticate
+        </button>
+        <button id="copy-cookie-btn" class="hover-text-cta" title="Copy cookie" type="button">📋</button>
+      </div>
     </div>
 
     <!-- Add Environment Form (static) -->
@@ -323,6 +326,18 @@
           .map(pre => pre.textContent)
           .join('\n');
         navigator.clipboard.writeText(logs);
+      });
+    }
+    const cookieBtn = document.getElementById('copy-cookie-btn');
+    if (cookieBtn) {
+      cookieBtn.addEventListener('click', function() {
+        fetch('/auth_cookie')
+          .then(res => res.json())
+          .then(data => {
+            if (data.cookie) {
+              navigator.clipboard.writeText(data.cookie);
+            }
+          });
       });
     }
     initEditor();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,3 +26,19 @@ def test_logout_removes_password(client):
     with client.session_transaction() as sess:
         assert 'user_password' not in sess
 
+
+def test_auth_cookie_endpoint(client):
+    from app import http_session
+    http_session.cookies.set('MOCA-WS-SESSIONKEY', 'cookie123')
+    # Not logged in should give 401
+    resp = client.get('/auth_cookie')
+    assert resp.status_code == 401
+
+    with client.session_transaction() as sess:
+        sess['username'] = 'SUPER'
+
+    resp2 = client.get('/auth_cookie')
+    assert resp2.status_code == 200
+    assert resp2.get_json()['cookie'] == 'cookie123'
+    http_session.cookies.clear()
+


### PR DESCRIPTION
## Summary
- expose current auth cookie via `/auth_cookie`
- capture the `MOCA-WS-SESSIONKEY` value on authentication
- add copy-cookie buttons in environment views
- support copying the cookie in JS
- test the cookie endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2382bed0832e91279945d58ed32e