### PR TITLE
Add tabular view with export

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,6 @@
 from flask import Flask, render_template, request, redirect, url_for, session, jsonify, make_response
+import io
+import csv
 from db import init_db, get_db_connection, log_request
 import requests
 import jmespath
@@ -487,6 +489,59 @@ def get_results():
     if not is_logged_in():
         return jsonify({'error': 'Not logged in'}), 401
     return jsonify(session.get('results', []))
+
+
+def _flatten_json(obj, prefix=''):
+    flat = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            flat.update(_flatten_json(v, f"{prefix}{k}."))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            flat.update(_flatten_json(v, f"{prefix}{i}."))
+    else:
+        flat[prefix[:-1]] = obj
+    return flat
+
+
+@app.route('/export_results')
+def export_results():
+    if not is_logged_in():
+        return jsonify({'error': 'Not logged in'}), 401
+    fmt = request.args.get('format', 'csv')
+    results = session.get('results', [])
+    rows = []
+    headers = set()
+    for item in results:
+        flat = _flatten_json(item.get('response')) if isinstance(item.get('response'), (dict, list)) else {'response': item.get('response')}
+        flat['command'] = item.get('command')
+        rows.append(flat)
+        headers.update(flat.keys())
+    headers = ['command'] + sorted(h for h in headers if h != 'command')
+    if fmt == 'xlsx':
+        from openpyxl import Workbook
+        wb = Workbook()
+        ws = wb.active
+        ws.append(headers)
+        for row in rows:
+            ws.append([row.get(h, '') for h in headers])
+        output = io.BytesIO()
+        wb.save(output)
+        output.seek(0)
+        resp = make_response(output.read())
+        resp.headers['Content-Disposition'] = 'attachment; filename=results.xlsx'
+        resp.mimetype = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        return resp
+    else:
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=headers)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({h: row.get(h, '') for h in headers})
+        resp = make_response(output.getvalue())
+        resp.headers['Content-Disposition'] = 'attachment; filename=results.csv'
+        resp.mimetype = 'text/csv'
+        return resp
 
 
 @app.route('/request_logs')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.1.0
 requests>=2.25
 jmespath>=1.0
 pytest>=8.0
+openpyxl>=3.1

--- a/templates/main.html
+++ b/templates/main.html
@@ -309,8 +309,19 @@
   </div>
   <div class="bg-primary text-main p-4 rounded shadow">
     <h3 class="text-lg font-semibold mb-2">API Responses</h3>
+    <div class="mb-2 space-x-2">
+      <button type="button" id="json-tab" class="tab-btn bg-secondary text-background px-3 py-1 rounded" data-tab="json">JSON</button>
+      <button type="button" id="table-tab" class="tab-btn px-3 py-1 rounded" data-tab="table">Table</button>
+      <a href="/export_results?format=csv" id="export-csv" class="px-2 py-1 bg-accent text-main rounded hidden" download>Export CSV</a>
+      <a href="/export_results?format=xlsx" id="export-xlsx" class="px-2 py-1 bg-accent text-main rounded hidden" download>Export XLSX</a>
+    </div>
     <input type="text" id="search-input" placeholder="Search in responses..." class="w-full border rounded px-2 py-1 mb-3">
-    <div id="results-container" class="space-y-4"></div>
+    <div id="tab-json" class="tab-content">
+      <div id="results-container" class="space-y-4"></div>
+    </div>
+    <div id="tab-table" class="tab-content hidden overflow-auto">
+      <table id="results-table" class="table-auto border-collapse text-sm"></table>
+    </div>
   </div>
 </div>
 
@@ -423,6 +434,10 @@
       .then(data => renderResults(data));
   }
   function renderResults(data) {
+    renderJson(data);
+    renderTable(data);
+  }
+  function renderJson(data) {
     const container = document.getElementById('results-container');
     container.innerHTML = '';
     data.forEach(item => {
@@ -432,10 +447,79 @@
       container.appendChild(div);
     });
   }
+
+  function flattenObject(obj, prefix = '') {
+    let out = {};
+    if (Array.isArray(obj)) {
+      obj.forEach((v, i) => {
+        Object.assign(out, flattenObject(v, `${prefix}${i}.`));
+      });
+    } else if (obj !== null && typeof obj === 'object') {
+      Object.entries(obj).forEach(([k, v]) => {
+        Object.assign(out, flattenObject(v, `${prefix}${k}.`));
+      });
+    } else {
+      out[prefix.slice(0, -1)] = obj;
+    }
+    return out;
+  }
+
+  function renderTable(data) {
+    const table = document.getElementById('results-table');
+    table.innerHTML = '';
+    const rows = [];
+    const headersSet = new Set(['command']);
+    data.forEach(item => {
+      const flat = typeof item.response === 'object' ? flattenObject(item.response) : { response: item.response };
+      flat['command'] = item.command;
+      rows.push(flat);
+      Object.keys(flat).forEach(k => headersSet.add(k));
+    });
+    const headers = Array.from(headersSet);
+    const thead = document.createElement('thead');
+    const hRow = document.createElement('tr');
+    headers.forEach(h => {
+      const th = document.createElement('th');
+      th.textContent = h;
+      th.className = 'border px-2 py-1';
+      hRow.appendChild(th);
+    });
+    thead.appendChild(hRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    rows.forEach(r => {
+      const tr = document.createElement('tr');
+      headers.forEach(h => {
+        const td = document.createElement('td');
+        td.textContent = r[h] !== undefined ? r[h] : '';
+        td.className = 'border px-2 py-1';
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+  }
+
   document.getElementById('search-input').addEventListener('input', function() {
     const term = this.value.toLowerCase();
     document.querySelectorAll('#results-container div').forEach(div => {
       div.style.display = div.textContent.toLowerCase().includes(term) ? '' : 'none';
+    });
+    document.querySelectorAll('#results-table tbody tr').forEach(tr => {
+      tr.style.display = tr.textContent.toLowerCase().includes(term) ? '' : 'none';
+    });
+  });
+
+  document.querySelectorAll('#json-tab, #table-tab').forEach(btn => {
+    btn.addEventListener('click', function() {
+      const target = this.dataset.tab;
+      document.querySelectorAll('#tab-json, #tab-table').forEach(c => c.classList.add('hidden'));
+      document.getElementById('tab-' + target).classList.remove('hidden');
+      document.querySelectorAll('#json-tab, #table-tab').forEach(b => b.classList.remove('bg-secondary', 'text-background'));
+      this.classList.add('bg-secondary', 'text-background');
+      const showExport = target === 'table';
+      document.getElementById('export-csv').classList.toggle('hidden', !showExport);
+      document.getElementById('export-xlsx').classList.toggle('hidden', !showExport);
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- export results as CSV or XLSX via new `/export_results` route
- show API responses in JSON or table view with download buttons
- flatten JSON responses client-side for table view
- install openpyxl dependency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b20baad88832e807d5428558f3d7a