### PR TITLE
Fix log section height

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -46,3 +46,8 @@ input:focus, textarea:focus, select:focus {
 .cm-dblue { color: darkblue; }
 .cm-lblue { color: #1e90ff; }
 .cm-comment { color: green; }
+
+/* Limit Live Log feed height */
+#log-section {
+    height: 20rem;
+}


### PR DESCRIPTION
## Summary
- limit the log section's height so large responses don't expand the page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685acad6f564832e8e6ac47a00b1863b